### PR TITLE
Update PSGeneratePagesAction.php

### DIFF
--- a/includes/PSGeneratePagesAction.php
+++ b/includes/PSGeneratePagesAction.php
@@ -25,7 +25,7 @@ class PSGeneratePagesAction extends Action {
 	 * @return bool
 	 */
 	public function show() {
-		$title = $this->page->getTitle();
+		$title = $this->getWikiPage()->getTitle();
 
 		// These tabs should only exist for category pages
 		if ( $title->getNamespace() != NS_CATEGORY ) {


### PR DESCRIPTION
$this->page inherited from action.php is deprecated since 1.35. Changed for $this->getWikiPage()