### PR TITLE
Update PSEditSchemaAction.php

### DIFF
--- a/includes/PSEditSchemaAction.php
+++ b/includes/PSEditSchemaAction.php
@@ -28,7 +28,7 @@ class PSEditSchemaAction extends Action {
 	 * @return bool
 	 */
 	public function show() {
-		$title = $this->page->getTitle();
+		$title = $this->getWikiPage()->getTitle();
 
 		// These tabs should only exist for category pages
 		if ( $title->getNamespace() != NS_CATEGORY ) {


### PR DESCRIPTION
$this->page inherited from action.php is deprecated since 1.35. Changed for $this->getWikiPage()